### PR TITLE
Update numpy and None test for array

### DIFF
--- a/georaster/georaster.py
+++ b/georaster/georaster.py
@@ -707,7 +707,7 @@ class __Raster:
             print("Xpixels and Ypixels must have the same size")
             return 1
 
-        if (Xpixels is None) & (Ypixels is None):
+        if type(Xpixels) is not np.ndarray and type(Ypixels) is not np.ndarray:
             Xpixels = np.arange(self.nx)
             Ypixels = np.arange(self.ny)
             Xpixels, Ypixels = np.meshgrid(Xpixels,Ypixels)


### PR DESCRIPTION
"is None" or "==None" does not work as intended for arrays with recent numpy versions (>1.1 I think);

Thus this also simplifies dependencies required to run this script with recent Python packages (could not get an up-to-date version of old packages to make it work on my machine).

With those 2 changes, the following up-to-date environment should now suffice (careful with numpy version here because of gdal):

Create environment:
conda create --name <env_name> python=2.7.15
conda install -c conda-forge gdal=2.2.2 basemap=1.1.0 pyproj georaster

sometimes need to specify the proper numpy/ncurses package, for me on Linux it works forcing:

numpy=1.15.1=py27h1d66e8a_0
ncurses=6.1=hfc679d8_1    conda-forge

Unfortunately, will depend on the OS..